### PR TITLE
IllegalStateException when changing orientation with parent-Fragment as targetFragment

### DIFF
--- a/library/src/eu/inmite/android/lib/dialogs/SimpleDialogFragment.java
+++ b/library/src/eu/inmite/android/lib/dialogs/SimpleDialogFragment.java
@@ -134,6 +134,9 @@ public class SimpleDialogFragment extends BaseDialogFragment {
 			if (targetFragment instanceof ISimpleDialogListener) {
 				return (ISimpleDialogListener) targetFragment;
 			}
+		} else if (getParentFragment() != null
+				&& getParentFragment() instanceof ISimpleDialogListener) {
+			return (ISimpleDialogListener) getParentFragment();
 		} else {
 			if (getActivity() instanceof ISimpleDialogListener) {
 				return (ISimpleDialogListener) getActivity();
@@ -148,6 +151,9 @@ public class SimpleDialogFragment extends BaseDialogFragment {
 			if (targetFragment instanceof ISimpleDialogCancelListener) {
 				return (ISimpleDialogCancelListener) targetFragment;
 			}
+		} else if (getParentFragment() != null
+				&& getParentFragment() instanceof ISimpleDialogCancelListener) {
+			return (ISimpleDialogCancelListener) getParentFragment();
 		} else {
 			if (getActivity() instanceof ISimpleDialogCancelListener) {
 				return (ISimpleDialogCancelListener) getActivity();


### PR DESCRIPTION
Unless parent Fragment is retained, setting parent-Fragment as targetFragment will cause an IllegalStateException when changing orientation (or restoring from savedInstance), because the SimpleDialogFragment will be recreated before the parent has been restored.

This:

```
mBuilder.setTargetFragment((Fragment) this, mRequestCode)
```

Will cause:

```
java.lang.IllegalStateException: Fragement no longer exists for key android:target_state: index 1
```

Proposed solution: fallback first to parent-Fragment if no targetFragment is set, then fallback to Activity if SimpleDialogFragment has no parent-Fragment.
