### PR TITLE
support RTL languages

### DIFF
--- a/library/src/main/res/layout/dialog_part_message.xml
+++ b/library/src/main/res/layout/dialog_part_message.xml
@@ -3,5 +3,6 @@
               android:id="@+id/sdl__contentPanel"
               style="@style/SDL.Group.Wrap">
     <TextView android:id="@+id/sdl__message"
+              android:layout_width="fill_parent"
               style="?attr/sdlMessageTextStyle" />
 </ScrollView>


### PR DESCRIPTION
by default android puts the gravity for the RTL languages to the right
but when the layout_width="wrap_content" it set the gravity to the right but it'll align the text view to the left of the parent by default 

by making the layout_width="fill_parent" android will be able to set the gravity to the right and align the text view to left and our text will get to the right and everyone is happy

**this will not affect the LTR lang and it's tested on ''7, ''5, ''4, inches screens 
