### PR TITLE
OnCancelListener support for ProgressDialogBuilder

### DIFF
--- a/library/src/main/java/com/avast/android/dialogs/fragment/ProgressDialogFragment.java
+++ b/library/src/main/java/com/avast/android/dialogs/fragment/ProgressDialogFragment.java
@@ -12,6 +12,7 @@ import android.widget.TextView;
 import com.avast.android.dialogs.R;
 import com.avast.android.dialogs.core.BaseDialogBuilder;
 import com.avast.android.dialogs.core.BaseDialogFragment;
+import com.avast.android.dialogs.fragment.SimpleDialogFragment;
 import com.avast.android.dialogs.iface.ISimpleDialogCancelListener;
 
 /**
@@ -27,105 +28,116 @@ import com.avast.android.dialogs.iface.ISimpleDialogCancelListener;
  */
 public class ProgressDialogFragment extends BaseDialogFragment {
 
-	protected final static String ARG_MESSAGE = "message";
-	protected final static String ARG_TITLE = "title";
+    protected final static String ARG_MESSAGE = "message";
+    protected final static String ARG_TITLE = "title";
 
-	protected int mRequestCode;
+    protected int mRequestCode;
+    protected static ISimpleDialogCancelListener mSimpleDialogCancelListener = null;
 
-	public static ProgressDialogBuilder createBuilder(Context context, FragmentManager fragmentManager) {
-		return new ProgressDialogBuilder(context, fragmentManager);
-	}
+    public static ProgressDialogBuilder createBuilder(Context context, FragmentManager fragmentManager) {
+        return new ProgressDialogBuilder(context, fragmentManager);
+    }
 
-	@Override
-	protected Builder build(Builder builder) {
-		final LayoutInflater inflater = builder.getLayoutInflater();
-		final View view = inflater.inflate(R.layout.sdl_progress, null, false);
-		final TextView tvMessage = (TextView) view.findViewById(R.id.sdl_message);
-		tvMessage.setText(getArguments().getString(ARG_MESSAGE));
+    @Override
+    protected Builder build(Builder builder) {
+        final LayoutInflater inflater = builder.getLayoutInflater();
+        final View view = inflater.inflate(R.layout.sdl_progress, null, false);
+        final TextView tvMessage = (TextView) view.findViewById(R.id.sdl_message);
+        tvMessage.setText(getArguments().getString(ARG_MESSAGE));
 
-		builder.setView(view);
+        builder.setView(view);
 
-		builder.setTitle(getArguments().getString(ARG_TITLE));
+        builder.setTitle(getArguments().getString(ARG_TITLE));
 
-		return builder;
-	}
+        return builder;
+    }
 
-	@Override
-	public void onActivityCreated(Bundle savedInstanceState) {
-		super.onActivityCreated(savedInstanceState);
-		if (getArguments() == null) {
-			throw new IllegalArgumentException("use ProgressDialogBuilder to construct this dialog");
-		}
-		final Fragment targetFragment = getTargetFragment();
-		mRequestCode = targetFragment != null ?
-				getTargetRequestCode() : getArguments().getInt(BaseDialogBuilder.ARG_REQUEST_CODE, 0);
-	}
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        if (getArguments() == null) {
+            throw new IllegalArgumentException("use ProgressDialogBuilder to construct this dialog");
+        }
+        final Fragment targetFragment = getTargetFragment();
+        mRequestCode = targetFragment != null ?
+                getTargetRequestCode() : getArguments().getInt(BaseDialogBuilder.ARG_REQUEST_CODE, 0);
+    }
 
-	@Override
-	public void onCancel(DialogInterface dialog) {
-		super.onCancel(dialog);
-		ISimpleDialogCancelListener listener = getCancelListener();
-		if (listener != null) {
-			listener.onCancelled(mRequestCode);
-		}
-	}
+    @Override
+    public void onCancel(DialogInterface dialog) {
+        super.onCancel(dialog);
+        ISimpleDialogCancelListener listener = getCancelListener();
+        if (listener != null) {
+            listener.onCancelled(mRequestCode);
+        }
+    }
 
-	protected ISimpleDialogCancelListener getCancelListener() {
-		final Fragment targetFragment = getTargetFragment();
-		if (targetFragment != null) {
-			if (targetFragment instanceof ISimpleDialogCancelListener) {
-				return (ISimpleDialogCancelListener) targetFragment;
-			}
-		} else {
-			if (getActivity() instanceof ISimpleDialogCancelListener) {
-				return (ISimpleDialogCancelListener) getActivity();
-			}
-		}
-		return null;
-	}
+    protected ISimpleDialogCancelListener getCancelListener() {
+        final Fragment targetFragment = getTargetFragment();
+        
+        if (mSimpleDialogCancelListener != null)
+            return mSimpleDialogCancelListener;
+        
+        if (targetFragment != null) {
+            if (targetFragment instanceof ISimpleDialogCancelListener) {
+                return (ISimpleDialogCancelListener) targetFragment;
+            }
+        } else {
+            if (getActivity() instanceof ISimpleDialogCancelListener) {
+                return (ISimpleDialogCancelListener) getActivity();
+            }
+        }
+        
+        return null;
+    }
 
-	public static class ProgressDialogBuilder extends BaseDialogBuilder<ProgressDialogBuilder> {
+    public static class ProgressDialogBuilder extends BaseDialogBuilder<ProgressDialogBuilder> {
 
-		private String mTitle;
-		private String mMessage;
+        private String mTitle;
+        private String mMessage;
 
-		protected ProgressDialogBuilder(Context context, FragmentManager fragmentManager) {
-			super(context, fragmentManager, ProgressDialogFragment.class);
-		}
+        protected ProgressDialogBuilder(Context context, FragmentManager fragmentManager) {
+            super(context, fragmentManager, ProgressDialogFragment.class);
+        }
 
-		@Override
-		protected ProgressDialogBuilder self() {
-			return this;
-		}
+        @Override
+        protected ProgressDialogBuilder self() {
+            return this;
+        }
 
-		public ProgressDialogBuilder setTitle(int titleResourceId) {
-			mTitle = mContext.getString(titleResourceId);
-			return this;
-		}
+        public ProgressDialogBuilder setTitle(int titleResourceId) {
+            mTitle = mContext.getString(titleResourceId);
+            return this;
+        }
 
 
-		public ProgressDialogBuilder setTitle(String title) {
-			mTitle = title;
-			return this;
-		}
+        public ProgressDialogBuilder setTitle(String title) {
+            mTitle = title;
+            return this;
+        }
 
-		public ProgressDialogBuilder setMessage(int messageResourceId) {
-			mMessage = mContext.getString(messageResourceId);
-			return this;
-		}
+        public ProgressDialogBuilder setMessage(int messageResourceId) {
+            mMessage = mContext.getString(messageResourceId);
+            return this;
+        }
 
-		public ProgressDialogBuilder setMessage(String message) {
-			mMessage = message;
-			return this;
-		}
+        public ProgressDialogBuilder setMessage(String message) {
+            mMessage = message;
+            return this;
+        }
 
-		@Override
-		protected Bundle prepareArguments() {
-			Bundle args = new Bundle();
-			args.putString(SimpleDialogFragment.ARG_MESSAGE, mMessage);
-			args.putString(SimpleDialogFragment.ARG_TITLE, mTitle);
+        public ProgressDialogBuilder setOnCancelListener(ISimpleDialogCancelListener mCancelListener) {
+            ProgressDialogFragment.mSimpleDialogCancelListener = mCancelListener;
+            return this;
+        }
 
-			return args;
-		}
-	}
+        @Override
+        protected Bundle prepareArguments() {
+            Bundle args = new Bundle();
+            args.putString(SimpleDialogFragment.ARG_MESSAGE, mMessage);
+            args.putString(SimpleDialogFragment.ARG_TITLE, mTitle);
+
+            return args;
+        }
+    }
 }


### PR DESCRIPTION
I have done a mod to make possible to set a ISimpleDialogCancelListener with ProgressDialogBuilder inside something different from an activity or a fragment:

ProgressDialogFragment.createBuilder(activity,
                    activity().getSupportFragmentManager())
                    .setTitle(context.getString(R.string.progressDialogTitle))
                    .setMessage(context.getString(R.string.progressDialogMessage))
                    .setCancelable(true)
                    .setOnCancelListener(this)
                    .show();

this snippet of code for example can be executed from inside an AsynkTask and when the dialog is cancelled the task can be interrupted.