### PR TITLE
Dialogs fixed for tablets

### DIFF
--- a/library/src/main/res/layout/sdl_dialog.xml
+++ b/library/src/main/res/layout/sdl_dialog.xml
@@ -34,27 +34,28 @@
         android:id="@+id/sdl_button_divider"
         style="@style/SDL.Divider" />
 
-    <LinearLayout
+    <RelativeLayout
         android:id="@+id/sdl_buttons_default"
         style="@style/SDL.Layout.Buttons">
 
         <Button
             android:id="@+id/sdl_button_neutral"
-            style="@style/SDL.Button"
+            style="@style/SDL.Button.Neutral"
             tools:text="Neutral" />
 
-        <View style="@style/SDL.Expander" />
-
-        <Button
-            android:id="@+id/sdl_button_negative"
-            style="@style/SDL.Button"
-            tools:text="Negative" />
-
-        <Button
-            android:id="@+id/sdl_button_positive"
-            style="@style/SDL.Button"
-            tools:text="Positive" />
-    </LinearLayout>
+        <LinearLayout
+            android:id="@+id/sdl_buttons_default_right"
+            style="@style/SDL.Layout.Buttons.Right">
+            <Button
+                android:id="@+id/sdl_button_negative"
+                style="@style/SDL.Button"
+                tools:text="Negative" />
+            <Button
+                android:id="@+id/sdl_button_positive"
+                style="@style/SDL.Button"
+                tools:text="Positive" />
+        </LinearLayout>
+    </RelativeLayout>
 
     <LinearLayout
         android:id="@+id/sdl_buttons_stacked"

--- a/library/src/main/res/values/sdl_styles.xml
+++ b/library/src/main/res/values/sdl_styles.xml
@@ -53,11 +53,19 @@
     </style>
 
     <style name="SDL.Layout.Buttons">
-        <item name="android:orientation">horizontal</item>
         <item name="android:layout_height">@dimen/grid_12</item>
-        <item name="android:gravity">center_vertical</item>
+        <item name="android:layout_width">match_parent</item>
         <item name="android:paddingLeft">@dimen/grid_3</item>
         <item name="android:paddingRight">@dimen/grid_3</item>
+        <item name="android:layout_gravity">center_vertical</item>
+        <item name="android:gravity">center_vertical</item>
+    </style>
+
+    <style name="SDL.Layout.Buttons.Right">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">match_parent</item>
+        <item name="android:orientation">horizontal</item>
+        <item name="android:layout_alignParentRight">true</item>
     </style>
 
     <style name="SDL.Layout.Buttons.Stacked">
@@ -147,7 +155,7 @@
         <item name="android:layout_width">wrap_content</item>
         <item name="android:minWidth">@dimen/grid_16</item>
         <item name="android:layout_height">@dimen/grid_9</item>
-        <item name="android:gravity">center</item>
+        <item name="android:layout_gravity">center</item>
         <item name="android:paddingRight">@dimen/grid_2</item>
         <item name="android:paddingLeft">@dimen/grid_2</item>
         <item name="android:layout_marginRight">@dimen/grid_1</item>
@@ -156,6 +164,11 @@
         <item name="android:textAllCaps" tools:ignore="NewApi">true</item>
         <item name="android:singleLine">true</item>
         <item name="android:textColor">?colorAccent</item>
+    </style>
+
+    <style name="SDL.Button.Neutral" parent="@style/SDL.Button">
+        <item name="android:layout_alignParentLeft">true</item>
+        <item name="android:layout_centerVertical">true</item>
     </style>
 
     <style name="SDL.Button.Stacked">


### PR DESCRIPTION
I have replaced the dialog buttons linearlayout with a relativelayout to avoid the "expander" match parent. So the dialog is not so big on tablets.