### PR TITLE
useLightTheme() for forcing light theme on individual dialogs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: android
 script: "./gradlew assembleDebug"
 android:
   components:
-    - build-tools-20.0.0
-    - android-21
+    - build-tools-22
+    - android-22
     - extra-android-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: android
 script: "./gradlew assembleDebug"
 android:
   components:
-    - build-tools-22
+    - build-tools-22.0.0
     - android-22
     - extra-android-m2repository

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ It uses standard Material colors, for example like this:
 ```
 
 For dark theme, inherit from `Theme.AppCompat`. Or you can force dark theme per individual dialog using `useDarkTheme()` builder method.
+You can also force light theme per individual dialog using `useLightTheme()` builder method.
 
 ## How to create simple dialogs:
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "20"
+    compileSdkVersion 22
+    buildToolsVersion "22"
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionName project.VERSION_NAME
         versionCode project.VERSION_CODE
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -7,19 +7,19 @@ ext {
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "20"
+    compileSdkVersion 22
+    buildToolsVersion "22"
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionName project.VERSION_NAME
         versionCode project.VERSION_CODE
     }
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:21.0.3'
+    compile 'com.android.support:appcompat-v7:22.0.0'
 }
 
 apply from: 'android-release-aar.gradle'

--- a/library/src/main/java/com/avast/android/dialogs/core/BaseDialogBuilder.java
+++ b/library/src/main/java/com/avast/android/dialogs/core/BaseDialogBuilder.java
@@ -21,6 +21,7 @@ public abstract class BaseDialogBuilder<T extends BaseDialogBuilder<T>> {
     public final static int DEFAULT_REQUEST_CODE = -42;
     private int mRequestCode = DEFAULT_REQUEST_CODE;
     public static String ARG_USE_DARK_THEME = "usedarktheme";
+    public static String ARG_USE_LIGHT_THEME = "uselighttheme";
     protected final Context mContext;
     protected final FragmentManager mFragmentManager;
     protected final Class<? extends BaseDialogFragment> mClass;
@@ -28,6 +29,7 @@ public abstract class BaseDialogBuilder<T extends BaseDialogBuilder<T>> {
     private boolean mCancelable = true;
     private boolean mCancelableOnTouchOutside = true;
     private boolean mUseDarkTheme = false;
+    private boolean mUseLightTheme = false;
 
     public BaseDialogBuilder(Context context, FragmentManager fragmentManager, Class<? extends BaseDialogFragment> clazz) {
         mFragmentManager = fragmentManager;
@@ -73,6 +75,11 @@ public abstract class BaseDialogBuilder<T extends BaseDialogBuilder<T>> {
         return self();
     }
 
+    public T useLightTheme() {
+        mUseLightTheme = true;
+        return self();
+    }
+
     private BaseDialogFragment create() {
         final Bundle args = prepareArguments();
 
@@ -81,6 +88,8 @@ public abstract class BaseDialogBuilder<T extends BaseDialogBuilder<T>> {
         args.putBoolean(ARG_CANCELABLE_ON_TOUCH_OUTSIDE, mCancelableOnTouchOutside);
 
         args.putBoolean(ARG_USE_DARK_THEME, mUseDarkTheme);
+
+        args.putBoolean(ARG_USE_LIGHT_THEME, mUseLightTheme);
 
         if (mTargetFragment != null) {
             fragment.setTargetFragment(mTargetFragment, mRequestCode);

--- a/library/src/main/java/com/avast/android/dialogs/core/BaseDialogFragment.java
+++ b/library/src/main/java/com/avast/android/dialogs/core/BaseDialogFragment.java
@@ -72,6 +72,9 @@ public abstract class BaseDialogFragment extends DialogFragment implements Dialo
             if (args.getBoolean(BaseDialogBuilder.ARG_USE_DARK_THEME)) {
                 //Developer is explicitly using the dark theme
                 darkTheme = true;
+            } else if (args.getBoolean(BaseDialogBuilder.ARG_USE_LIGHT_THEME)) {
+                //Developer is explicitly using the light theme
+                darkTheme = false;
             } else {
                 //Dynamically detecting the theme declared in manifest
                 resolveTheme();


### PR DESCRIPTION
I implemented useLightTheme() builder method in an identical way as useDarkTheme is, and reused darkTheme variable for the purpose. Setting it to false explicitly is for clarity. 

Also updated the project to newest SDK/appcompat.