### PR TITLE
Make it possible to style the dialog with a custom theme.

### DIFF
--- a/demo/src/main/java/com/avast/dialogs/JayneHatDialogFragment.java
+++ b/demo/src/main/java/com/avast/dialogs/JayneHatDialogFragment.java
@@ -37,8 +37,14 @@ public class JayneHatDialogFragment extends SimpleDialogFragment {
     }
 
     @Override
+    public int getTheme() {
+        return R.style.JayneHatDialogTheme;
+    }
+
+    @Override
     public BaseDialogFragment.Builder build(BaseDialogFragment.Builder builder) {
         builder.setTitle("Jayne's hat");
+        builder.setMessage("A man walks down the street in that hat, people know he's not afraid of anything.");
         builder.setView(LayoutInflater.from(getActivity()).inflate(R.layout.view_jayne_hat, null));
         builder.setPositiveButton("I want one", new View.OnClickListener() {
             @Override

--- a/demo/src/main/res/values/colors.xml
+++ b/demo/src/main/res/values/colors.xml
@@ -4,4 +4,11 @@
     <color name="primary">#3C4655</color>
     <color name="primary_dark">#0E0E0E</color>
     <color name="accent">#F4982E</color>
+
+    <!-- custom jayne's hat dialog theme: -->
+    <color name="jayne_text_primary_light">#e8ffb300</color>
+    <color name="jayne_text_secondary_light">#e9b65b00</color>
+    <color name="jayne_divider_light">#1fff002b</color>
+    <color name="jayne_pressed_light">#c74e2c00</color>
+    <color name="jayne_accent">#f42e35</color>
 </resources>

--- a/demo/src/main/res/values/theme.xml
+++ b/demo/src/main/res/values/theme.xml
@@ -17,6 +17,14 @@
         <item name="actionOverflowButtonStyle">@style/OverFlow</item>
     </style>
 
+    <style name="JayneHatDialogTheme" parent="SDL.Dialog">
+        <item name="sdlTextPrimaryColor">@color/jayne_text_primary_light</item>
+        <item name="sdlTextSecondaryColor">@color/jayne_text_secondary_light</item>
+        <item name="sdlDividerColor">@color/jayne_divider_light</item>
+        <item name="sdlPressedColor">@color/jayne_pressed_light</item>
+        <item name="colorAccent">@color/jayne_accent</item>
+    </style>
+
     <style name="OverFlow" parent="Widget.AppCompat.ActionButton.Overflow">
         <item name="android:src">@drawable/ic_menu</item>
     </style>

--- a/library/src/main/res/drawable-v21/sdl_button_dark.xml
+++ b/library/src/main/res/drawable-v21/sdl_button_dark.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?colorControlHighlight">
-    <item android:drawable="@drawable/sdl_button_selector_dark" />
-</ripple>

--- a/library/src/main/res/drawable-v21/sdl_button_selector_dark.xml
+++ b/library/src/main/res/drawable-v21/sdl_button_selector_dark.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android" android:exitFadeDuration="@android:integer/config_shortAnimTime">
-    <item android:drawable="@drawable/sdl_button_pressed_dark" android:state_pressed="true" />
-    <item android:drawable="@drawable/sdl_button_normal" />
-</selector>

--- a/library/src/main/res/drawable-v21/sdl_list_dark.xml
+++ b/library/src/main/res/drawable-v21/sdl_list_dark.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?colorControlHighlight">
-    <item android:drawable="@drawable/sdl_list_selector_dark" />
-</ripple>

--- a/library/src/main/res/drawable-v21/sdl_list_selector_dark.xml
+++ b/library/src/main/res/drawable-v21/sdl_list_selector_dark.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android" android:exitFadeDuration="@android:integer/config_shortAnimTime">
-    <item android:drawable="@drawable/sdl_list_pressed_dark" android:state_pressed="true" />
-    <item android:drawable="@drawable/sdl_list_normal" />
-</selector>

--- a/library/src/main/res/drawable/sdl_button_dark.xml
+++ b/library/src/main/res/drawable/sdl_button_dark.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" android:exitFadeDuration="@android:integer/config_shortAnimTime" tools:ignore="UnusedAttribute">
-    <item android:drawable="@drawable/sdl_button_pressed_dark" android:state_pressed="true" />
-    <item android:drawable="@drawable/sdl_button_normal" />
-</selector>

--- a/library/src/main/res/drawable/sdl_button_pressed.xml
+++ b/library/src/main/res/drawable/sdl_button_pressed.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <corners android:radius="2dp" />
-    <solid android:color="@color/sdl_pressed_light" />
+    <solid android:color="?sdlPressedColor" />
 </shape>

--- a/library/src/main/res/drawable/sdl_button_pressed_dark.xml
+++ b/library/src/main/res/drawable/sdl_button_pressed_dark.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <corners android:radius="2dp" />
-    <solid android:color="@color/sdl_pressed_dark" />
-</shape>

--- a/library/src/main/res/drawable/sdl_list_dark.xml
+++ b/library/src/main/res/drawable/sdl_list_dark.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" android:exitFadeDuration="@android:integer/config_shortAnimTime" tools:ignore="UnusedAttribute">
-    <item android:drawable="@drawable/sdl_list_pressed_dark" android:state_pressed="true" />
-    <item android:drawable="@drawable/sdl_list_normal" />
-</selector>

--- a/library/src/main/res/drawable/sdl_list_pressed.xml
+++ b/library/src/main/res/drawable/sdl_list_pressed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/sdl_pressed_light" />
+    <solid android:color="?sdlPressedColor" />
 </shape>

--- a/library/src/main/res/drawable/sdl_list_pressed_dark.xml
+++ b/library/src/main/res/drawable/sdl_list_pressed_dark.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="@color/sdl_pressed_dark" />
-</shape>

--- a/library/src/main/res/values-v21/sdl_styles.xml
+++ b/library/src/main/res/values-v21/sdl_styles.xml
@@ -36,7 +36,7 @@
         <item name="sdlTextSecondaryColor">@color/sdl_text_secondary_dark</item>
         <item name="sdlDividerColor">@color/sdl_divider_dark</item>
         <item name="sdlPressedColor">@color/sdl_pressed_dark</item>
-        <item name="sdlButtonBackground">@drawable/sdl_button_dark</item>
-        <item name="sdlListSelector">@drawable/sdl_list_dark</item>
+        <item name="sdlButtonBackground">@drawable/sdl_button</item>
+        <item name="sdlListSelector">@drawable/sdl_list</item>
     </style>
 </resources>

--- a/library/src/main/res/values/sdl_styles.xml
+++ b/library/src/main/res/values/sdl_styles.xml
@@ -33,8 +33,6 @@
         <item name="sdlTextSecondaryColor">@color/sdl_text_secondary_dark</item>
         <item name="sdlDividerColor">@color/sdl_divider_dark</item>
         <item name="sdlPressedColor">@color/sdl_pressed_dark</item>
-        <item name="sdlButtonBackground">@drawable/sdl_button_dark</item>
-        <item name="sdlListSelector">@drawable/sdl_list_dark</item>
     </style>
 
     <style name="SDL.Layout">


### PR DESCRIPTION
Also uses the ?sdlPressedColor attribute for the pressed states instead of the hardcoded colors. This makes *_dark.xml drawables useless, so they were deleted.

The custom theme was used for the "Custom dialog" in the Demo app.