### PR TITLE
Ability to pass more information to callbacks.

### DIFF
--- a/demo/src/main/java/com/avast/dialogs/DemoActivity.java
+++ b/demo/src/main/java/com/avast/dialogs/DemoActivity.java
@@ -32,6 +32,7 @@ import android.view.View;
 import android.widget.AbsListView;
 import android.widget.Toast;
 
+import com.avast.android.dialogs.core.BaseDialogFragment;
 import com.avast.android.dialogs.fragment.DatePickerDialogFragment;
 import com.avast.android.dialogs.fragment.ListDialogFragment;
 import com.avast.android.dialogs.fragment.ProgressDialogFragment;
@@ -201,15 +202,16 @@ public class DemoActivity extends ActionBarActivity implements
     // IListDialogListener
 
     @Override
-    public void onListItemSelected(CharSequence value, int number, int requestCode) {
+    public void onListItemSelected(CharSequence value, int number, BaseDialogFragment dialog) {
+        final int requestCode = dialog.getRequestCode();
         if (requestCode == REQUEST_LIST_SIMPLE || requestCode == REQUEST_LIST_SINGLE) {
             Toast.makeText(c, "Selected: " + value, Toast.LENGTH_SHORT).show();
         }
     }
 
     @Override
-    public void onListItemsSelected(CharSequence[] values, int[] selectedPositions, int requestCode) {
-        if (requestCode == REQUEST_LIST_MULTIPLE) {
+    public void onListItemsSelected(CharSequence[] values, int[] selectedPositions, BaseDialogFragment dialog) {
+        if (dialog.getRequestCode() == REQUEST_LIST_MULTIPLE) {
             StringBuilder sb = new StringBuilder();
             for (CharSequence value : values) {
                 if (sb.length() > 0) {
@@ -225,8 +227,8 @@ public class DemoActivity extends ActionBarActivity implements
     // ISimpleDialogCancelListener
 
     @Override
-    public void onCancelled(int requestCode) {
-        switch (requestCode) {
+    public void onCancelled(BaseDialogFragment dialog) {
+        switch (dialog.getRequestCode()) {
             case REQUEST_SIMPLE_DIALOG:
                 Toast.makeText(c, "Dialog cancelled", Toast.LENGTH_SHORT).show();
                 break;
@@ -250,22 +252,22 @@ public class DemoActivity extends ActionBarActivity implements
     // ISimpleDialogListener
 
     @Override
-    public void onPositiveButtonClicked(int requestCode) {
-        if (requestCode == REQUEST_SIMPLE_DIALOG) {
+    public void onPositiveButtonClicked(BaseDialogFragment dialog) {
+        if (dialog.getRequestCode() == REQUEST_SIMPLE_DIALOG) {
             Toast.makeText(c, "Positive button clicked", Toast.LENGTH_SHORT).show();
         }
     }
 
     @Override
-    public void onNegativeButtonClicked(int requestCode) {
-        if (requestCode == REQUEST_SIMPLE_DIALOG) {
+    public void onNegativeButtonClicked(BaseDialogFragment dialog) {
+        if (dialog.getRequestCode() == REQUEST_SIMPLE_DIALOG) {
             Toast.makeText(c, "Negative button clicked", Toast.LENGTH_SHORT).show();
         }
     }
 
     @Override
-    public void onNeutralButtonClicked(int requestCode) {
-        if (requestCode == REQUEST_SIMPLE_DIALOG) {
+    public void onNeutralButtonClicked(BaseDialogFragment dialog) {
+        if (dialog.getRequestCode() == REQUEST_SIMPLE_DIALOG) {
             Toast.makeText(c, "Neutral button clicked", Toast.LENGTH_SHORT).show();
         }
     }
@@ -273,11 +275,12 @@ public class DemoActivity extends ActionBarActivity implements
     // IDateDialogListener
 
     @Override
-    public void onNegativeButtonClicked(int resultCode, Date date) {
+    public void onNegativeButtonClicked(BaseDialogFragment dialog, Date date) {
         String text = "";
-        if (resultCode == REQUEST_DATE_PICKER) {
+        final int requestCode = dialog.getRequestCode();
+        if (requestCode == REQUEST_DATE_PICKER) {
             text = "Date ";
-        } else if (resultCode == REQUEST_TIME_PICKER) {
+        } else if (requestCode == REQUEST_TIME_PICKER) {
             text = "Time ";
         }
 
@@ -286,11 +289,12 @@ public class DemoActivity extends ActionBarActivity implements
     }
 
     @Override
-    public void onPositiveButtonClicked(int resultCode, Date date) {
+    public void onPositiveButtonClicked(BaseDialogFragment dialog, Date date) {
         String text = "";
-        if (resultCode == REQUEST_DATE_PICKER) {
+        final int requestCode = dialog.getRequestCode();
+        if (requestCode == REQUEST_DATE_PICKER) {
             text = "Date ";
-        } else if (resultCode == REQUEST_TIME_PICKER) {
+        } else if (requestCode == REQUEST_TIME_PICKER) {
             text = "Time ";
         }
 

--- a/demo/src/main/java/com/avast/dialogs/JayneHatDialogFragment.java
+++ b/demo/src/main/java/com/avast/dialogs/JayneHatDialogFragment.java
@@ -50,7 +50,7 @@ public class JayneHatDialogFragment extends SimpleDialogFragment {
             @Override
             public void onClick(View v) {
                 for (IPositiveButtonDialogListener listener : getPositiveButtonDialogListeners()) {
-                    listener.onPositiveButtonClicked(mRequestCode);
+                    listener.onPositiveButtonClicked(JayneHatDialogFragment.this);
                 }
                 dismiss();
             }

--- a/library/src/main/java/com/avast/android/dialogs/core/BaseDialogBuilder.java
+++ b/library/src/main/java/com/avast/android/dialogs/core/BaseDialogBuilder.java
@@ -16,6 +16,7 @@ public abstract class BaseDialogBuilder<T extends BaseDialogBuilder<T>> {
 
     public final static String ARG_REQUEST_CODE = "request_code";
     public final static String ARG_CANCELABLE_ON_TOUCH_OUTSIDE = "cancelable_oto";
+    public final static String ARG_EXTRAS = "extras";
     public final static String DEFAULT_TAG = "simple_dialog";
     private String mTag = DEFAULT_TAG;
     public final static int DEFAULT_REQUEST_CODE = -42;
@@ -30,6 +31,7 @@ public abstract class BaseDialogBuilder<T extends BaseDialogBuilder<T>> {
     private boolean mCancelableOnTouchOutside = true;
     private boolean mUseDarkTheme = false;
     private boolean mUseLightTheme = false;
+    private Bundle mExtras;
 
     public BaseDialogBuilder(Context context, FragmentManager fragmentManager, Class<? extends BaseDialogFragment> clazz) {
         mFragmentManager = fragmentManager;
@@ -80,6 +82,11 @@ public abstract class BaseDialogBuilder<T extends BaseDialogBuilder<T>> {
         return self();
     }
 
+    public T setExtras(Bundle extras) {
+        mExtras = extras == null ? null : new Bundle(extras);
+        return self();
+    }
+
     private BaseDialogFragment create() {
         final Bundle args = prepareArguments();
 
@@ -96,6 +103,12 @@ public abstract class BaseDialogBuilder<T extends BaseDialogBuilder<T>> {
         } else {
             args.putInt(ARG_REQUEST_CODE, mRequestCode);
         }
+
+        final Bundle extras = mExtras;
+        if (extras != null) {
+            args.putBundle(ARG_EXTRAS, extras);
+        }
+
         fragment.setCancelable(mCancelable);
         return fragment;
     }

--- a/library/src/main/java/com/avast/android/dialogs/core/BaseDialogFragment.java
+++ b/library/src/main/java/com/avast/android/dialogs/core/BaseDialogFragment.java
@@ -58,7 +58,7 @@ import com.avast.android.dialogs.util.TypefaceHelper;
  */
 public abstract class BaseDialogFragment extends DialogFragment implements DialogInterface.OnShowListener {
 
-    protected int mRequestCode;
+    private int mRequestCode;
 
     @NonNull
     @Override
@@ -144,8 +144,12 @@ public abstract class BaseDialogFragment extends DialogFragment implements Dialo
     public void onCancel(DialogInterface dialog) {
         super.onCancel(dialog);
         for (ISimpleDialogCancelListener listener : getCancelListeners()) {
-            listener.onCancelled(mRequestCode);
+            listener.onCancelled(this);
         }
+    }
+
+    public final int getRequestCode() {
+        return mRequestCode;
     }
 
     /**

--- a/library/src/main/java/com/avast/android/dialogs/fragment/DatePickerDialogFragment.java
+++ b/library/src/main/java/com/avast/android/dialogs/fragment/DatePickerDialogFragment.java
@@ -1,5 +1,10 @@
 package com.avast.android.dialogs.fragment;
 
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
 import android.content.Context;
 import android.os.Bundle;
 import android.support.v4.app.FragmentManager;
@@ -12,11 +17,6 @@ import com.avast.android.dialogs.R;
 import com.avast.android.dialogs.core.BaseDialogBuilder;
 import com.avast.android.dialogs.core.BaseDialogFragment;
 import com.avast.android.dialogs.iface.IDateDialogListener;
-
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
-import java.util.TimeZone;
 
 /**
  * Dialog with a date picker.
@@ -66,7 +66,7 @@ public class DatePickerDialogFragment extends BaseDialogFragment {
                 @Override
                 public void onClick(View view) {
                     for (IDateDialogListener listener : getDialogListeners()) {
-                        listener.onPositiveButtonClicked(mRequestCode, getDate());
+                        listener.onPositiveButtonClicked(DatePickerDialogFragment.this, getDate());
                     }
                     dismiss();
                 }
@@ -80,7 +80,7 @@ public class DatePickerDialogFragment extends BaseDialogFragment {
                 @Override
                 public void onClick(View view) {
                     for (IDateDialogListener listener : getDialogListeners()) {
-                        listener.onNegativeButtonClicked(mRequestCode, getDate());
+                        listener.onNegativeButtonClicked(DatePickerDialogFragment.this, getDate());
                     }
                     dismiss();
                 }

--- a/library/src/main/java/com/avast/android/dialogs/fragment/ListDialogFragment.java
+++ b/library/src/main/java/com/avast/android/dialogs/fragment/ListDialogFragment.java
@@ -132,7 +132,7 @@ public class ListDialogFragment extends BaseDialogFragment {
                 @Override
                 public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                     for (IListDialogListener listener : getSingleDialogListeners()) {
-                        listener.onListItemSelected(getItems()[position], position, mRequestCode);
+                        listener.onListItemSelected(getItems()[position], position, ListDialogFragment.this);
                     }
                     dismiss();
                 }
@@ -151,7 +151,7 @@ public class ListDialogFragment extends BaseDialogFragment {
                 @Override
                 public void onClick(View view) {
                     for (ISimpleDialogCancelListener listener : getCancelListeners()) {
-                        listener.onCancelled(mRequestCode);
+                        listener.onCancelled(ListDialogFragment.this);
                     }
                     dismiss();
                 }
@@ -178,7 +178,7 @@ public class ListDialogFragment extends BaseDialogFragment {
                             }
 
                             for (IMultiChoiceListDialogListener listener : getMutlipleDialogListeners()) {
-                                listener.onListItemsSelected(checkedValues, checkedPositions, mRequestCode);
+                                listener.onListItemsSelected(checkedValues, checkedPositions, ListDialogFragment.this);
                             }
                             dismiss();
                         }
@@ -203,11 +203,12 @@ public class ListDialogFragment extends BaseDialogFragment {
                             // either item is selected or dialog is cancelled
                             if (selectedPosition != -1) {
                                 for (IListDialogListener listener : getSingleDialogListeners()) {
-                                    listener.onListItemSelected(items[selectedPosition], selectedPosition, mRequestCode);
+                                    listener.onListItemSelected(items[selectedPosition], selectedPosition,
+                                        ListDialogFragment.this);
                                 }
                             } else {
                                 for (ISimpleDialogCancelListener listener : getCancelListeners()) {
-                                    listener.onCancelled(mRequestCode);
+                                    listener.onCancelled(ListDialogFragment.this);
                                 }
                             }
                             dismiss();

--- a/library/src/main/java/com/avast/android/dialogs/fragment/ListDialogFragment.java
+++ b/library/src/main/java/com/avast/android/dialogs/fragment/ListDialogFragment.java
@@ -177,7 +177,7 @@ public class ListDialogFragment extends BaseDialogFragment {
                                 }
                             }
 
-                            for (IMultiChoiceListDialogListener listener : getMutlipleDialogListeners()) {
+                            for (IMultiChoiceListDialogListener listener : getMultipleDialogListeners()) {
                                 listener.onListItemsSelected(checkedValues, checkedPositions, ListDialogFragment.this);
                             }
                             dismiss();
@@ -264,7 +264,7 @@ public class ListDialogFragment extends BaseDialogFragment {
      * @return Dialog listeners
      * @since 2.1.0
      */
-    private List<IMultiChoiceListDialogListener> getMutlipleDialogListeners() {
+    private List<IMultiChoiceListDialogListener> getMultipleDialogListeners() {
         return getDialogListeners(IMultiChoiceListDialogListener.class);
     }
 

--- a/library/src/main/java/com/avast/android/dialogs/fragment/SimpleDialogFragment.java
+++ b/library/src/main/java/com/avast/android/dialogs/fragment/SimpleDialogFragment.java
@@ -16,6 +16,8 @@
 
 package com.avast.android.dialogs.fragment;
 
+import java.util.List;
+
 import android.content.Context;
 import android.os.Bundle;
 import android.support.v4.app.FragmentManager;
@@ -29,8 +31,6 @@ import com.avast.android.dialogs.core.BaseDialogFragment;
 import com.avast.android.dialogs.iface.INegativeButtonDialogListener;
 import com.avast.android.dialogs.iface.INeutralButtonDialogListener;
 import com.avast.android.dialogs.iface.IPositiveButtonDialogListener;
-
-import java.util.List;
 
 
 /**
@@ -81,7 +81,7 @@ public class SimpleDialogFragment extends BaseDialogFragment {
                 @Override
                 public void onClick(View view) {
                     for (IPositiveButtonDialogListener listener : getPositiveButtonDialogListeners()) {
-                        listener.onPositiveButtonClicked(mRequestCode);
+                        listener.onPositiveButtonClicked(SimpleDialogFragment.this);
                     }
                     dismiss();
                 }
@@ -94,7 +94,7 @@ public class SimpleDialogFragment extends BaseDialogFragment {
                 @Override
                 public void onClick(View view) {
                     for (INegativeButtonDialogListener listener : getNegativeButtonDialogListeners()) {
-                        listener.onNegativeButtonClicked(mRequestCode);
+                        listener.onNegativeButtonClicked(SimpleDialogFragment.this);
                     }
                     dismiss();
                 }
@@ -107,7 +107,7 @@ public class SimpleDialogFragment extends BaseDialogFragment {
                 @Override
                 public void onClick(View view) {
                     for (INeutralButtonDialogListener listener : getNeutralButtonDialogListeners()) {
-                        listener.onNeutralButtonClicked(mRequestCode);
+                        listener.onNeutralButtonClicked(SimpleDialogFragment.this);
                     }
                     dismiss();
                 }

--- a/library/src/main/java/com/avast/android/dialogs/iface/IDateDialogListener.java
+++ b/library/src/main/java/com/avast/android/dialogs/iface/IDateDialogListener.java
@@ -18,6 +18,8 @@ package com.avast.android.dialogs.iface;
 
 import java.util.Date;
 
+import com.avast.android.dialogs.core.BaseDialogFragment;
+
 /**
  * Implement this interface in Activity or Fragment to react to positive and negative buttons of date/time dialog.
  *
@@ -25,7 +27,7 @@ import java.util.Date;
  */
 public interface IDateDialogListener {
 
-    public void onPositiveButtonClicked(int requestCode, Date date);
+    void onPositiveButtonClicked(BaseDialogFragment dialog, Date date);
 
-    public void onNegativeButtonClicked(int requestCode, Date date);
+    void onNegativeButtonClicked(BaseDialogFragment dialog, Date date);
 }

--- a/library/src/main/java/com/avast/android/dialogs/iface/IListDialogListener.java
+++ b/library/src/main/java/com/avast/android/dialogs/iface/IListDialogListener.java
@@ -1,10 +1,12 @@
 package com.avast.android.dialogs.iface;
 
+import com.avast.android.dialogs.core.BaseDialogFragment;
+
 /**
  * Interface for ListDialogFragment in modes: CHOICE_MODE_NONE, CHOICE_MODE_SINGLE
  * Implement it in Activity or Fragment to react to item selection.
  */
 public interface IListDialogListener {
 
-    public void onListItemSelected(CharSequence value, int number, int requestCode);
+    void onListItemSelected(CharSequence value, int number, BaseDialogFragment dialog);
 }

--- a/library/src/main/java/com/avast/android/dialogs/iface/IMultiChoiceListDialogListener.java
+++ b/library/src/main/java/com/avast/android/dialogs/iface/IMultiChoiceListDialogListener.java
@@ -1,5 +1,7 @@
 package com.avast.android.dialogs.iface;
 
+import com.avast.android.dialogs.core.BaseDialogFragment;
+
 /**
  * Interface for ListDialogFragment in modes: CHOICE_MODE_MULTIPLE
  * Implement it in Activity or Fragment to react to item selection.
@@ -8,5 +10,5 @@ package com.avast.android.dialogs.iface;
  */
 public interface IMultiChoiceListDialogListener {
 
-    public void onListItemsSelected(CharSequence[] values, int[] selectedPositions, int requestCode);
+    void onListItemsSelected(CharSequence[] values, int[] selectedPositions, BaseDialogFragment dialog);
 }

--- a/library/src/main/java/com/avast/android/dialogs/iface/INegativeButtonDialogListener.java
+++ b/library/src/main/java/com/avast/android/dialogs/iface/INegativeButtonDialogListener.java
@@ -1,5 +1,7 @@
 package com.avast.android.dialogs.iface;
 
+import com.avast.android.dialogs.core.BaseDialogFragment;
+
 /**
  * Implement this interface in Activity or Fragment to react to negative dialog buttons.
  *
@@ -8,5 +10,5 @@ package com.avast.android.dialogs.iface;
  */
 public interface INegativeButtonDialogListener {
 
-    public void onNegativeButtonClicked(int requestCode);
+    void onNegativeButtonClicked(BaseDialogFragment dialog);
 }

--- a/library/src/main/java/com/avast/android/dialogs/iface/INeutralButtonDialogListener.java
+++ b/library/src/main/java/com/avast/android/dialogs/iface/INeutralButtonDialogListener.java
@@ -1,5 +1,7 @@
 package com.avast.android.dialogs.iface;
 
+import com.avast.android.dialogs.core.BaseDialogFragment;
+
 /**
  * Implement this interface in Activity or Fragment to react to neutral dialog buttons.
  *
@@ -8,5 +10,5 @@ package com.avast.android.dialogs.iface;
  */
 public interface INeutralButtonDialogListener {
 
-    public void onNeutralButtonClicked(int requestCode);
+    void onNeutralButtonClicked(BaseDialogFragment dialog);
 }

--- a/library/src/main/java/com/avast/android/dialogs/iface/IPositiveButtonDialogListener.java
+++ b/library/src/main/java/com/avast/android/dialogs/iface/IPositiveButtonDialogListener.java
@@ -1,5 +1,7 @@
 package com.avast.android.dialogs.iface;
 
+import com.avast.android.dialogs.core.BaseDialogFragment;
+
 /**
  * Implement this interface in Activity or Fragment to react to positive dialog buttons.
  *
@@ -8,5 +10,5 @@ package com.avast.android.dialogs.iface;
  */
 public interface IPositiveButtonDialogListener {
 
-    public void onPositiveButtonClicked(int requestCode);
+    void onPositiveButtonClicked(BaseDialogFragment dialog);
 }

--- a/library/src/main/java/com/avast/android/dialogs/iface/ISimpleDialogCancelListener.java
+++ b/library/src/main/java/com/avast/android/dialogs/iface/ISimpleDialogCancelListener.java
@@ -16,6 +16,8 @@
 
 package com.avast.android.dialogs.iface;
 
+import com.avast.android.dialogs.core.BaseDialogFragment;
+
 /**
  * Implement this interface in Activity or Fragment to react when the dialog is cancelled.
  * This listener is common for all types of dialogs.
@@ -24,5 +26,5 @@ package com.avast.android.dialogs.iface;
  */
 public interface ISimpleDialogCancelListener {
 
-    public void onCancelled(int requestCode);
+    void onCancelled(BaseDialogFragment dialog);
 }


### PR DESCRIPTION
Key changes:
- **Breaking change**: `int requestCode` replaced by `BaseDialogFragment dialog`. 
- Added `BaseDialogBuilder.setExtras(Bundle)`.
- Added `BaseDialogFragment.getRequestCode()`.

You can now handle more information about dialog in callbacks. For example you ask user to confirm delete item from list. Now you can pass item id in extras and then get it from `dialog.getArguments().getBundle(BaseDialogBuilder.ARG_EXTRAS)`.
